### PR TITLE
Improved error message

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -266,7 +266,7 @@ impl UsbContext for GlobalContext {
                 USB_CONTEXT = match libusb_init(context.as_mut_ptr()) {
                     0 => context.assume_init(),
                     err => panic!(
-                        "Can't init Global usb context, error {:?}",
+                        "Can't init Global usb context (this can happen if no USB devices are plugged in), error {:?}",
                         error::from_libusb(err)
                     ),
                 }


### PR DESCRIPTION
If no USB devices are present, libusb will fail to load. This affects Qubes and possibly other environments. We can't control whether the libusb_init() returns an error, but this patch does improve the error message explaining why the library may have failed to load.

This came out of the bug report here: https://github.com/a1ien/rusb/issues/218